### PR TITLE
fix(react-ssr-prepass.d.ts): use `export default`

### DIFF
--- a/scripts/react-ssr-prepass.d.ts
+++ b/scripts/react-ssr-prepass.d.ts
@@ -14,5 +14,5 @@ declare module '@plasmicapp/react-ssr-prepass' {
     clientRefVisitor?: ClientReferenceVisitor
   ): Promise<void>
 
-  export = ssrPrepass
+  export default ssrPrepass
 }


### PR DESCRIPTION
We need to import this package directly because we need to fork some of the plasmic's prepass code (such as this https://github.com/plasmicapp/plasmic/blob/master/packages/prepass/src/index.tsx ), because we need to set up swr by ourselves.

However, this is currently impossible to us, because when importing this package, we get such an error during typescript compilation:

```log
$ tsc -p tsconfig.package.json
node_modules/@plasmicapp/react-ssr-prepass/dist/react-ssr-prepass.d.ts:17:3 - error TS2309: An export assignment cannot be used in a module with other exported elements.

17   export = ssrPrepass
     ~~~~~~~~~~~~~~~~~~~


Found 1 error in node_modules/@plasmicapp/react-ssr-prepass/dist/react-ssr-prepass.d.ts:17

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

This change makes the error disappear.